### PR TITLE
Cherry-Pick: Add options to attach pre/postfix to rate value

### DIFF
--- a/cloudkittydashboard/dashboards/project/rating/views.py
+++ b/cloudkittydashboard/dashboards/project/rating/views.py
@@ -22,6 +22,12 @@ from horizon import tables
 from cloudkittydashboard.api import cloudkitty as api
 from cloudkittydashboard.dashboards.project.rating \
     import tables as rating_tables
+from cloudkittydashboard import utils
+
+rate_prefix = getattr(settings,
+                      'OPENSTACK_CLOUDKITTY_RATE_PREFIX', None)
+rate_postfix = getattr(settings,
+                       'OPENSTACK_CLOUDKITTY_RATE_POSTFIX', None)
 
 
 class IndexView(tables.DataTableView):
@@ -38,6 +44,9 @@ class IndexView(tables.DataTableView):
         total = sum([r.get('rate') for r in data])
 
         data.append({'type': 'TOTAL', 'rate': total})
+        for item in data:
+            item['rate'] = utils.formatRate(item['rate'],
+                                            rate_prefix, rate_postfix)
         return data
 
 

--- a/cloudkittydashboard/utils.py
+++ b/cloudkittydashboard/utils.py
@@ -25,3 +25,12 @@ class TemplatizableDict(dict):
 
     def __setattr__(self, key, val):
         self[key] = val
+
+
+def formatRate(rate: float, prefix: str, postfix: str) -> str:
+    rate = str(rate)
+    if prefix:
+        rate = prefix + rate
+    if postfix:
+        rate = rate + postfix
+    return rate

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -40,3 +40,37 @@ For more detailed information about CloudKitty installation check out the
 
 
 .. _installation section: https://cloudkitty.readthedocs.org/en/latest/installation.html
+
+
+Configuration
+=============
+
+To configure CloudKitty dashboard, add variables to your Horizon settings
+file.
+For more details about how to add variables to Horizon settings checkout the
+`Horizon Settings Reference documentation`_.
+
+
+.. _Horizon Settings Reference documentation: https://docs.openstack.org/horizon/latest/configuration/settings.html
+
+Rate Pre/Postfix
+----------------
+
+You can configure pre/postfix to rate vaules shown at the dashboard.
+
+Here's example of setting rate currency to US Dollar.
+
+.. code-block:: python
+
+   # You can choose to have prefix or postfix or both.
+   # Prefix and postfix are not mutally exclusive.
+   OPENSTACK_CLOUDKITTY_RATE_PREFIX = '$'
+   OPENSTACK_CLOUDKITTY_RATE_POSTFIX = 'USD'
+
+Some symbols (Such as Non-ASCII) might require to use unicode value directly.
+
+.. code-block:: python
+
+   # British Pound
+   OPENSTACK_CLOUDKITTY_RATE_PREFIX = u'\xA3'
+   OPENSTACK_CLOUDKITTY_RATE_POSTFIX = 'GBP'

--- a/releasenotes/notes/add-options-to-attach-pre-post-fix-to-rate-value-2d78f5cb7c289445.yaml
+++ b/releasenotes/notes/add-options-to-attach-pre-post-fix-to-rate-value-2d78f5cb7c289445.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Adds optional Horizon settings variable OPENSTACK_CLOUDKITTY_RATE_PREFIX
+    and OPENSTACK_CLOUDKITTY_RATE_POSTFIX. These allow users to attach
+    pre/postfix to their rate vaules shown at the dashboard such as currency.
+    These values can be set in ``.py`` settings snippets under
+    ``openstack_dashboard/local/local_settings.d`` directory. Follow
+    https://docs.openstack.org/horizon/latest/configuration/settings.html
+    for more details.


### PR DESCRIPTION
Adds optional Horizon settings variable
``OPENSTACK_CLOUDKITTY_RATE_PREFIX`` and
``OPENSTACK_CLOUDKITTY_RATE_POSTFIX``.

These allow users to set pre/postfix to rate vaules shown at the dashboard such as currency.

Change-Id: Ib663d29be9cee48aec94934a170ea80554538e0d