### PR TITLE
Pass Flavor and source info under metadata dict

### DIFF
--- a/cloudkittydashboard/static/cloudkitty/js/cloudkitty.controller.js
+++ b/cloudkittydashboard/static/cloudkitty/js/cloudkitty.controller.js
@@ -21,17 +21,19 @@
       var disk_total = $scope.model.newInstanceSpec.flavor.ephemeral + $scope.model.newInstanceSpec.flavor.disk;
 
       var desc_form = {
-        'flavor_name': $scope.model.newInstanceSpec.flavor.name,
-        'flavor_id': $scope.model.newInstanceSpec.flavor.id,
+        'metadata': {
+            'flavor_name': $scope.model.newInstanceSpec.flavor.name,
+            'flavor_id': $scope.model.newInstanceSpec.flavor.id,
+            'source_type': $scope.model.newInstanceSpec.source_type.type,
+            'source_val': $scope.model.newInstanceSpec.source[0].id,
+            'image_id': $scope.model.newInstanceSpec.source[0].id,
+        },
         'vcpus': $scope.model.newInstanceSpec.flavor.vcpus,
         'disk': $scope.model.newInstanceSpec.flavor.disk,
         'ephemeral': $scope.model.newInstanceSpec.flavor.ephemeral,
         'disk_total': disk_total,
         'disk_total_display': disk_total,
         'ram': $scope.model.newInstanceSpec.flavor.ram,
-        'source_type': $scope.model.newInstanceSpec.source_type.type,
-        'source_val': $scope.model.newInstanceSpec.source[0].id,
-        'image_id': $scope.model.newInstanceSpec.source[0].id,
       }
 
       var form_data = [{"desc": desc_form, "volume": $scope.model.newInstanceSpec.instance_count}];

--- a/cloudkittydashboard/static/cloudkitty/js/pricing.js
+++ b/cloudkittydashboard/static/cloudkitty/js/pricing.js
@@ -65,9 +65,11 @@ pricing = {
 
             // make the json data form
             desc_form = {
-                'flavor': flavor,
-                'source_type': source_type,
-                'source_val': source_val, // images : horizon.Quota.findImageById(source_val);
+                'metadata': {
+                    'flavor': flavor,
+                    'source_type': source_type,
+                    'source_val': source_val, // images : horizon.Quota.findImageById(source_val);
+                },
                 'vcpus': vcpus,
                 'disk': disk,
                 'ephemeral': ephemeral,


### PR DESCRIPTION
Eternally cherry-picked downstream patch we've had for years. Adding it to 2026.1

Not sure if we still need it, but given how long we've carried it, I assume so?

(cherry picked from commit 01fbe079f6c0b1818c767424a16aad6e38d7f91d) (cherry picked from commit 3794c88a065001256e8c227c02577393174b9fc3) (cherry picked from commit c88978b8d24be7bc03b4ce4997844bd321d21e20) (cherry picked from commit a2f51633a4fe885cf54d43bcfa3b5c3c27e2c696) (cherry picked from commit 17445b79fdb4d255ad06d69e289fa8d1b832b452) (cherry picked from commit 6533b2239ab85a91314d8c1c2b1a4434c7782dac) (cherry picked from commit 0595325c2fa50cac0323391d6a36e9bedd947417) (cherry picked from commit 84fde688749d862ee8511e518ec963f7a961c8c4) (cherry picked from commit a6cdcf2eb0b1431974eacb46f190edc2e0be64c7)